### PR TITLE
canRejectAccount take User class object instead of int

### DIFF
--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -39,7 +39,8 @@ if (!isset($_POST['identifier'])) {
     );
 }
 
-$username = (\User::factory($_POST['identifier']))->getUsername();
+$rejectee = \User::factory($_POST['identifier']);
+$username = $rejectee->getUsername();
 
 if (empty($username)) {
     header("HTTP/1.1 404 Not Found");
@@ -49,7 +50,7 @@ if (empty($username)) {
     );
 }
 
-if (!Edit_User::canRejectAccount($username)) {
+if (!Edit_User::canRejectAccount($rejectee)) {
     header("HTTP/1.1 403 Forbidden");
     header("Content-Type: text/plain");
     exit(

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -828,7 +828,7 @@ class Edit_User extends \NDB_Form
     static function canRejectAccount(\User $user)
     {
         return $user->getData('Pending_approval') == 'Y'
-            && !$user->hasEverLoggedIn();
+            && !$user->hasLoggedIn();
     }
 
     /**

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -721,7 +721,7 @@ class Edit_User extends \NDB_Form
             $this->tpl_data['can_reject'] = false;
         } else {
             $this->tpl_data['can_reject']
-                = self::canRejectAccount($this->identifier);
+                = self::canRejectAccount(\User::factory($this->identifier));
         }
 
         // get the editor's permissions
@@ -817,39 +817,18 @@ class Edit_User extends \NDB_Form
     }
 
     /**
-     * Query database on UserID to check that password hash does not
-     * exist and account is still pending approval.
-     *
      * This ensures that users with account activity cannot be rejected
      * if their approval status is, for some reason, set to pending.
      *
-     * @param string $userID of account to verify
+     * @param \User $user The User to verify
      *
-     * @return boolean true if 'Password_hash' is null and
-     *         'Pending_approval' is Yes. False, otherwise.
-     *
-     * @throws Loris exception if the userID is not found in the database.
+     * @return boolean true if 'Pending_approval' is Yes and the user never
+     *                      ever logged in.
      */
-    static function canRejectAccount($userID)
+    static function canRejectAccount(\User $user)
     {
-        $DB_factory = \NDB_Factory::singleton();
-        $DB         = $DB_factory->database();
-
-        $fields = $DB->pselectRow(
-            "SELECT Password_hash, Pending_approval
-                       FROM users
-                       WHERE UserID=:id",
-            array("id" => $userID)
-        );
-        if (empty($fields)) {
-            throw new \LorisException("User not found in database");
-        } else if (empty($fields['Password_hash'])
-            && $fields['Pending_approval']=="Y"
-        ) {
-            return true;
-        } else {
-            return false;
-        }
+        return $user->getData('Pending_approval') == 'Y'
+            && !$user->hasEverLoggedIn();
     }
 
     /**
@@ -1137,4 +1116,4 @@ class Edit_User extends \NDB_Form
         );
     }
 }
-?>
+

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -541,5 +541,24 @@ class User extends UserPermissions
         return $this->hasPermission($code)
             && $this->hasCenter($center_id);
     }
+
+    /**
+     * Determines if the user has ever logged in successfully
+     *
+     * @return bool
+     */
+    public function hasEverLoggedIn(): bool
+    {
+        $count = (\Database::singleton())->pselectOne(
+            "SELECT
+               COUNT(1)
+             FROM user_login_history 
+             WHERE
+               UserID = :v_userid AND
+               Success = 'Y'
+            ",
+            array('v_userid' => $this->userInfo['UserID'])
+        );
+        return $count > 0;
+    }
 }
-?>

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -547,9 +547,9 @@ class User extends UserPermissions
      *
      * @return bool
      */
-    public function hasEverLoggedIn(): bool
+    public function hasLoggedIn(): bool
     {
-        $count = (\Database::singleton())->pselectOne(
+        $count = (\NDB_Factory::singleton()->database())->pselectOne(
             "SELECT
                COUNT(1)
              FROM user_login_history 


### PR DESCRIPTION
make the canRejectAccount function take a user instead of a userid so it can call instance methods. The push the database query in the model obejct instead of the logic one
